### PR TITLE
Issue: Chat Automatically Closes on Page Reload

### DIFF
--- a/frontend/src/store/useAuthStore.js
+++ b/frontend/src/store/useAuthStore.js
@@ -1,73 +1,110 @@
-import {create} from  "zustand";
-import toast from "react-hot-toast";
+import { create } from "zustand";
 import {axiosInstance} from "../lib/axios.js";
-import { useAuthStore } from "./useAuthStore.js";
+import toast from "react-hot-toast";
+import { io } from "socket.io-client";
 
-export const useChatStore = create((set,get)=>({
-    messages:[],
-    users:[],
-    selectedUser: localStorage.getItem("selectedUser")
-    ? JSON.parse(localStorage.getItem("selectedUser"))
-    : null,
+const BASE_URL = import.meta.env.MODE==="development" ? "http://localhost:5000" : "/";
 
-    isUsersLoading:false,
-    isMessagesLoading: false,
+export const useAuthStore = create((set,get)=>({
+    authUser: null,
+    isSigningUp:false,
+    isLoggingIn: false,
+    isUpdatingProfile: false,
+    isCheckingAuth: true,
+    onlineUsers: [],
+    socket:null,
 
-    getUsers: async()=>{
-        set({isUsersLoading: true});
+    checkAuth: async() =>{
         try {
-            const res = await axiosInstance.get("/messages/users");
-            set({users: res.data});
+            // console.log("DEVENDRA");
+            const res = await axiosInstance.get("/auth/check");
+            // console.log("res from useAuthStore",res);
+            set({authUser: res.data});
+            
+            get().connectSocket();
+        } catch (error) {
+            console.log("Error in checkAuth:", error);
+            set({authUser:null});
+        } finally{
+            set({isCheckingAuth: false});
+        }
+    },
+
+    signup: async(data)=>{
+        set({isSigningUp:true});
+        try {
+            const res = await axiosInstance.post("/auth/signup",data);
+            set({authUser:res.data});
+            toast.success("Account created successfully");
+
+            get().connectSocket();
         } catch (error) {
             toast.error(error.response.data.message);
         }finally{
-            set({isUsersLoading:false});
+            set({ isSigningUp:false});
         }
     },
-    getMessages: async (userId)=>{
-        set({isMessagesLoading:true});
+
+    login: async (data) => {
+        set({ isLoggingIn: true });
         try {
-            const res = await axiosInstance.get(`/messages/${userId}`);
-            set({messages: res.data});
-        } catch (error) {
-            toast.error(error.response.data.message);
-        }finally{
-            set({isMessagesLoading:false});
-        }
-    },
-    sendMessage:async (messageData)=>{
-        const {selectedUser, messages}=get();
-        try {
-            const res = await axiosInstance.post(`/messages/send/${selectedUser._id}`, messageData);
-            set({messages:[...messages, res.data]});
-
-        } catch (error) {
-            toast.error(error.response.data.message);
-        }
-    },
-
-    subscribeToMessages:()=>{
-        const {selectedUser} = get();
-        if(!selectedUser) return;
-        
-        const socket = useAuthStore.getState().socket;
-
-        socket.on("newMessage",(newMessage)=> {
-            if(newMessage.senderId!== selectedUser._id) return;
-            set({
-                messages:[...get().messages, newMessage],
-            });
-        });
-    },
-
-    unsubscribeToMessages:()=>{
-        const socket = useAuthStore.getState().socket;
-        socket.off("newMessage");
-    },
-
-    setSelectedUser: (selectedUser) => {
-        set({ selectedUser });
-        localStorage.setItem("selectedUser", JSON.stringify(selectedUser));
-    },
+          const res = await axiosInstance.post("/auth/login", data);
+          set({ authUser: res.data });
+          toast.success("Logged in successfully");
     
-}))
+          get().connectSocket();
+        } catch (error) {
+          toast.error(error.response.data.message);
+        } finally {
+          set({ isLoggingIn: false });
+        }
+    },
+
+    logout: async()=>{
+        try {
+            await axiosInstance.post("/auth/logout");
+            set({authUser:null});
+            toast.success("Logged out successfully");
+
+            get().disconnectSocket();
+        } catch (error) {
+            toast.error(error.response.data.message);
+        }
+    },
+
+    updateProfile: async (data) => {
+        set({ isUpdatingProfile: true });
+        try {
+          const res = await axiosInstance.put("/auth/update-profile", data);
+          set({ authUser: res.data });
+          toast.success("Profile updated successfully");
+        } catch (error) {
+          console.log("error in update profile:", error);
+          toast.error(error.response.data.message);
+        } finally {
+          set({ isUpdatingProfile: false });
+        }
+    },
+
+    connectSocket:()=>{
+        const {authUser} = get();
+        if(!authUser || get().socket?.connected) return;
+
+        const socket = io(BASE_URL,{
+            query:{
+                userId: authUser._id,
+            }
+        });
+        socket.connect();
+        set({socket : socket});
+
+        socket.on("getOnlineUsers", (userIds)=>{
+            set({onlineUsers: userIds});
+        } );
+        
+    },
+
+    disconnectSocket:()=>{
+        if(get().socket?.connected) get().socket.disconnect();
+    },
+}));

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -1,68 +1,73 @@
-import { create } from "zustand";
+import {create} from  "zustand";
 import toast from "react-hot-toast";
-import { axiosInstance } from "../lib/axios";
-import { useAuthStore } from "./useAuthStore";
+import {axiosInstance} from "../lib/axios.js";
+import { useAuthStore } from "./useAuthStore.js";
 
-export const useChatStore = create((set, get) => ({
-  messages: [],
-  users: [],
-  selectedUser: null,
-  isUsersLoading: false,
-  isMessagesLoading: false,
+export const useChatStore = create((set,get)=>({
+    messages:[],
+    users:[],
+    selectedUser: localStorage.getItem("selectedUser")
+    ? JSON.parse(localStorage.getItem("selectedUser"))
+    : null,
 
-  getUsers: async () => {
-    set({ isUsersLoading: true });
-    try {
-      const res = await axiosInstance.get("/messages/users");
-      set({ users: res.data });
-    } catch (error) {
-      toast.error(error.response.data.message);
-    } finally {
-      set({ isUsersLoading: false });
-    }
-  },
+    isUsersLoading:false,
+    isMessagesLoading: false,
 
-  getMessages: async (userId) => {
-    set({ isMessagesLoading: true });
-    try {
-      const res = await axiosInstance.get(`/messages/${userId}`);
-      set({ messages: res.data });
-    } catch (error) {
-      toast.error(error.response.data.message);
-    } finally {
-      set({ isMessagesLoading: false });
-    }
-  },
-  sendMessage: async (messageData) => {
-    const { selectedUser, messages } = get();
-    try {
-      const res = await axiosInstance.post(`/messages/send/${selectedUser._id}`, messageData);
-      set({ messages: [...messages, res.data] });
-    } catch (error) {
-      toast.error(error.response.data.message);
-    }
-  },
+    getUsers: async()=>{
+        set({isUsersLoading: true});
+        try {
+            const res = await axiosInstance.get("/messages/users");
+            set({users: res.data});
+        } catch (error) {
+            toast.error(error.response.data.message);
+        }finally{
+            set({isUsersLoading:false});
+        }
+    },
+    getMessages: async (userId)=>{
+        set({isMessagesLoading:true});
+        try {
+            const res = await axiosInstance.get(`/messages/${userId}`);
+            set({messages: res.data});
+        } catch (error) {
+            toast.error(error.response.data.message);
+        }finally{
+            set({isMessagesLoading:false});
+        }
+    },
+    sendMessage:async (messageData)=>{
+        const {selectedUser, messages}=get();
+        try {
+            const res = await axiosInstance.post(`/messages/send/${selectedUser._id}`, messageData);
+            set({messages:[...messages, res.data]});
 
-  subscribeToMessages: () => {
-    const { selectedUser } = get();
-    if (!selectedUser) return;
+        } catch (error) {
+            toast.error(error.response.data.message);
+        }
+    },
 
-    const socket = useAuthStore.getState().socket;
+    subscribeToMessages:()=>{
+        const {selectedUser} = get();
+        if(!selectedUser) return;
+        
+        const socket = useAuthStore.getState().socket;
 
-    socket.on("newMessage", (newMessage) => {
-      const isMessageSentFromSelectedUser = newMessage.senderId === selectedUser._id;
-      if (!isMessageSentFromSelectedUser) return;
+        socket.on("newMessage",(newMessage)=> {
+            if(newMessage.senderId!== selectedUser._id) return;
+            set({
+                messages:[...get().messages, newMessage],
+            });
+        });
+    },
 
-      set({
-        messages: [...get().messages, newMessage],
-      });
-    });
-  },
+    unsubscribeToMessages:()=>{
+        const socket = useAuthStore.getState().socket;
+        socket.off("newMessage");
+    },
 
-  unsubscribeFromMessages: () => {
-    const socket = useAuthStore.getState().socket;
-    socket.off("newMessage");
-  },
-
-  setSelectedUser: (selectedUser) => set({ selectedUser }),
-}));
+    setSelectedUser: (selectedUser) => {
+        set({ selectedUser });
+        localStorage.setItem("selectedUser", JSON.stringify(selectedUser));
+    },
+    
+}))


### PR DESCRIPTION

When a user opens a chat with a specific user and reloads the page, the opened chat is automatically closed. This disrupts the user experience as the app does not retain the selected chat context after a page refresh.

**Expected Behavior**
The app should persist the selected chat so that, after reloading the page, the user is automatically returned to the chat they were viewing.

**Current Behavior**
The selectedUser state is reset to null on page reload, causing the opened chat to close. This requires the user to manually select the chat again.

**Steps to Reproduce**

1. Open a chat with a user.
2. Reload the page.
3. Observe that the opened chat is closed, and the user is returned to the default state.

**Proposed Solution**
Use _localStorage_ to persist the _selectedUser_ state. By storing the selectedUser object in localStorage as a string, we can retrieve it when the app initializes. This ensures the user's chat selection persists across page reloads.

**Code Changes**
Update the setSelectedUser function and selectedUser state initialization in the _useChatStore_ as follows:

Store selectedUser in localStorage:


```
setSelectedUser: (selectedUser) => {
    set({ selectedUser });
    localStorage.setItem("selectedUser", JSON.stringify(selectedUser));
},
```
Retrieve selectedUser on initialization:

```
selectedUser: localStorage.getItem("selectedUser")
    ? JSON.parse(localStorage.getItem("selectedUser"))
    : null,
```
**Benefits**

- Improved user experience by retaining the chat context after a reload.
- Aligns the application behavior with user expectations for a seamless chat experience.