### PR TITLE
Update Sidebar.jsx

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -38,7 +38,7 @@ const Sidebar = () => {
             />
             <span className="text-sm">Show online only</span>
           </label>
-          <span className="text-xs text-zinc-500">({onlineUsers.length - 1} online)</span>
+          <span className="text-xs text-zinc-500">({onlineUsers.length === 0 ?  0 : onlineUsers.length-1} online)</span>
         </div>
       </div>
 


### PR DESCRIPTION
Fixed online user count display in Sidebar  

- Updated the online user count logic to handle cases where `onlineUsers.length` is 0.  
- Previously, it subtracted 1 from the count, which could result in `-1` when no users were online.  
- Now, it correctly displays `0` when there are no online users.